### PR TITLE
Add system environment variables

### DIFF
--- a/install/action.yaml
+++ b/install/action.yaml
@@ -50,6 +50,10 @@ inputs:
     options:
       - 'conda'
       - 'mamba'
+  add-environment-variables:
+    description: Whether to add environment variables to the environment
+    required: false
+    default: 'true'
 outputs:
   cache-hit:
     description: Whether the cache was hit
@@ -79,6 +83,20 @@ runs:
       shell: bash -el {0}
     - if: runner.os != 'Windows'
       run: echo "ENVS_PATH=${{ format('{0}/{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
+      shell: bash -el {0}
+    - if: inputs.add-environment-variables == 'true'
+      run: |
+        # Set number of threads to 1 to avoid multiprocessing issues
+        # This is really conservative, but it is better to
+        # do it this way because it is pain to debug.
+        echo "OMP_NUM_THREADS=1" >> $GITHUB_ENV
+        echo "OPENBLAS_NUM_THREADS=1" >> $GITHUB_ENV
+        echo "MKL_NUM_THREADS=1" >> $GITHUB_ENV
+        echo "VECLIB_MAXIMUM_THREADS=1" >> $GITHUB_ENV
+        echo "NUMEXPR_NUM_THREADS=1" >> $GITHUB_ENV
+
+        # This is to avoid warnings for debugpy on newer versions of Python
+        echo "PYDEVD_DISABLE_FILE_VALIDATION=1" >> $GITHUB_ENV
       shell: bash -el {0}
     - if: inputs.cache == 'true'
       uses: actions/cache@v3


### PR DESCRIPTION
The NUM_THREADS variables are based on this [StackOverflow issue](https://stackoverflow.com/questions/30791550/limit-number-of-threads-in-numpy)

The `PYDEVD_DISABLE_FILE_VALIDATION` is to avoid this warning: 
![image](https://github.com/pyviz-dev/holoviz_tasks/assets/19758978/9e362737-6c0d-4c4a-8b78-e09cb5f24d3d)

Some more details about it is here: https://discourse.jupyter.org/t/debugger-warning-it-seems-that-frozen-modules-are-being-used-python-3-11-0