### PR TITLE
Try adding group

### DIFF
--- a/install/action.yaml
+++ b/install/action.yaml
@@ -62,7 +62,10 @@ runs:
         fetch-depth: "100"
       # Forcing fetch to avoid 'would clobber existing tag', as the previous step
       # fetches tags already.
-    - run: git fetch --prune --tags --unshallow --force
+    - run: |
+        echo "::group::Fetch tags"
+        git fetch --prune --tags --unshallow --force
+        echo "::endgroup::"
       shell: bash -el {0}
     - uses: actions/setup-python@v4
       with:
@@ -72,22 +75,14 @@ runs:
         miniconda-version: "latest"
         auto-update-conda: ${{ inputs.conda-update }}
         # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest version
-    - run: |
-        echo "::group::Setup $TODAY"
-        echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-        echo "::endgroup::"
+    - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}
+      name: Set $TODAY
     - if: runner.os == 'Windows'
-      run: |
-        echo "::group::Setup $ENVS_PATH"
-        echo "ENVS_PATH=${{ format('{0}\{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
-        echo "::endgroup::"
+      run: echo "ENVS_PATH=${{ format('{0}\{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
       shell: bash -el {0}
     - if: runner.os != 'Windows'
-      run: |
-        echo "::group::Setup $ENVS_PATH"
-        echo "ENVS_PATH=${{ format('{0}/{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
-        echo "::endgroup::"
+      run: echo "ENVS_PATH=${{ format('{0}/{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
       shell: bash -el {0}
     - if: inputs.cache == 'true'
       uses: actions/cache@v3

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -160,7 +160,7 @@ runs:
       shell: bash -el {0}
     - if: inputs.opengl == 'true' && runner.os == 'Linux' && (inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true')
       run: |
-        echo "::group::Install OpenGL (no cache)"
+        echo "::group::Install mesalib (no cache)"
         conda activate test-environment
         ${{ inputs.conda-mamba }} install mesalib
         echo "::endgroup::"

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -72,13 +72,22 @@ runs:
         miniconda-version: "latest"
         auto-update-conda: ${{ inputs.conda-update }}
         # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest version
-    - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+    - run: |
+        echo "::group::Setup $TODAY"
+        echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+        echo "::endgroup::"
       shell: bash -el {0}
     - if: runner.os == 'Windows'
-      run: echo "ENVS_PATH=${{ format('{0}\{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
+      run: |
+        echo "::group::Setup $ENVS_PATH"
+        echo "ENVS_PATH=${{ format('{0}\{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
+        echo "::endgroup::"
       shell: bash -el {0}
     - if: runner.os != 'Windows'
-      run: echo "ENVS_PATH=${{ format('{0}/{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
+      run: |
+        echo "::group::Setup $ENVS_PATH"
+        echo "ENVS_PATH=${{ format('{0}/{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
+        echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.cache == 'true'
       uses: actions/cache@v3
@@ -88,9 +97,11 @@ runs:
       id: cache
     - if: inputs.conda-mamba == 'mamba' && steps.cache.outputs.cache-hit != 'true'
       run: |
+        echo "::group::Setup mamba"
         echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
         conda install mamba -c conda-forge -n base
         conda run -n base mamba init --all
+        echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       uses: actions/setup-node@v1
@@ -98,6 +109,7 @@ runs:
        node-version: ${{ inputs.nodejs-version }}
     - if: steps.cache.outputs.cache-hit != 'true'
       run: |
+        echo "::group::Setup conda environment"
         conda create -n test-environment
         conda activate test-environment
         IFS="," read -a channels_array <<< ${{ inputs.channels }}
@@ -116,48 +128,65 @@ runs:
         conda config --show-sources
         conda info
         ${{ inputs.conda-mamba }} install python=${{ inputs.python-version }} pyctdev nomkl
+        echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.cache == 'true' && steps.cache.outputs.cache-hit == 'true'
       run: |
+        echo "::group::Installing package (with cache)"
         conda activate test-environment
         pip install -e . --no-deps --no-build-isolation
+        echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true'
       # Need || echo "Keep going" and pip install again to deal with
       # when pyctdev updates CPython itself. Dangerous as that could
       # hide other issues.
       run: |
+        echo "::group::Installing package (no cache)"
         conda activate test-environment
         doit develop_install ${{ inputs.envs }} --conda-mode=${{ inputs.conda-mamba }} || echo "Keep going"
         pip install -e . --no-deps --no-build-isolation
+        echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.opengl == 'true' && runner.os == 'Windows'
       run: |
+        echo "::group::Install OpenGL"
         git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
         powershell gl-ci-helpers/appveyor/install_opengl.ps1
+        echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.opengl == 'true' && runner.os == 'Linux'
       run: |
+        echo "::group::Install OpenGL"
         sudo apt-get install libglu1-mesa
         /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x24
         sleep 3
+        echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.opengl == 'true' && runner.os == 'Linux' && (inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true')
       run: |
+        echo "::group::Install OpenGL (no cache)"
         conda activate test-environment
         ${{ inputs.conda-mamba }} install mesalib
+        echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.playwright == 'true' && (inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true')
       run: |
+        echo "::group::Install playwright"
         conda activate test-environment
         pip install playwright pytest-playwright
+        echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.playwright == 'true'
       run: |
+        echo "::group::Install playwright browser"
         conda activate test-environment
         playwright install chromium
+        echo "::endgroup::"
       shell: bash -el {0}
     - run: |
+        echo "::group::Capture environment"
         conda activate test-environment
         doit env_capture
+        echo "::endgroup::"
       shell: bash -el {0}


### PR DESCRIPTION
This is meant to declutter the install task by putting all the steps of the actions into their own group, which makes the output collapsible and, therefore, easier to navigate.

I tried to look into if `Run echo "::group::..."` could have a more informative description, but I can see that in the github example, they also have it.

https://octocat.dev/posts/Groups-and-formatting-in-GitHub-Actions
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-grouping-log-lines