### PR TITLE
Update install action to only use conda+libmamba

### DIFF
--- a/install/action.yaml
+++ b/install/action.yaml
@@ -97,9 +97,9 @@ runs:
     - if: inputs.conda-mamba == 'mamba' && steps.cache.outputs.cache-hit != 'true'
       run: |
         echo "::group::Setup mamba"
-        echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
-        conda install -n base --override-channels -c conda-forge mamba 'python_abi=*=*cp*'
-        # conda run -n base mamba init --all
+        conda install -n base conda-libmamba-solver
+        conda config --set solver libmamba
+        echo "alias mamba=conda" >> ~/.bashrc
         echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
@@ -143,7 +143,7 @@ runs:
       run: |
         echo "::group::Installing package (no cache)"
         conda activate test-environment
-        doit develop_install ${{ inputs.envs }} --conda-mode=${{ inputs.conda-mamba }} || echo "Keep going"
+        doit develop_install ${{ inputs.envs }} || echo "Keep going"
         pip install -e . --no-deps --no-build-isolation
         echo "::endgroup::"
       shell: bash -el {0}
@@ -166,7 +166,7 @@ runs:
       run: |
         echo "::group::Install mesalib (no cache)"
         conda activate test-environment
-        ${{ inputs.conda-mamba }} install mesalib
+        conda install mesalib
         echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.playwright == 'true' && (inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true')

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -125,7 +125,7 @@ runs:
         conda config --env --set channel_priority ${{ inputs.channel-priority }}
         conda config --show-sources
         conda info
-        conda install python=${{ inputs.python-version }} pyctdev nomkl
+        conda install python=${{ inputs.python-version }} pyctdev nomkl conda-libmamba-solver
         echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.cache == 'true' && steps.cache.outputs.cache-hit == 'true'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -48,7 +48,7 @@ inputs:
     required: false
     default: 'false'
   conda-mamba:
-    description: Whether to use conda or mamba
+    description: "DEPRECATED: Whether to use conda or mamba"
     required: false
     default: 'conda'
     options:
@@ -94,9 +94,8 @@ runs:
         path: ${{ env.ENVS_PATH }}
         key: ${{ inputs.name  }}-${{ runner.os }}-${{ inputs.conda-mamba }}-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
       id: cache
-    - if: inputs.conda-mamba == 'mamba' && steps.cache.outputs.cache-hit != 'true'
-      run: |
-        echo "::group::Setup libmamba-solver"
+    - run: |
+        echo "::group::Setup conda-libmamba-solver"
         conda install -n base conda-libmamba-solver
         conda config --set solver libmamba
         echo "::endgroup::"

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -98,7 +98,8 @@ runs:
       run: |
         echo "::group::Setup mamba"
         echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
-        conda install mamba -c conda-forge -n base --solver classic
+        conda install conda-libmamba-solver -c conda-forge -n base
+        conda install mamba -c conda-forge -n base
         conda run -n base mamba init --all
         echo "::endgroup::"
       shell: bash -el {0}

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -98,8 +98,7 @@ runs:
       run: |
         echo "::group::Setup mamba"
         echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
-        conda install conda-libmamba-solver -c conda-forge -n base
-        conda install mamba -c conda-forge -n base
+        conda install -n base --override-channels -c conda-forge mamba 'python_abi=*=*cp*'
         conda run -n base mamba init --all
         echo "::endgroup::"
       shell: bash -el {0}

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -99,7 +99,7 @@ runs:
         echo "::group::Setup mamba"
         echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
         conda install -n base --override-channels -c conda-forge mamba 'python_abi=*=*cp*'
-        conda run -n base mamba init --all
+        # conda run -n base mamba init --all
         echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -15,6 +15,10 @@ inputs:
     description: Whether to update conda
     required: false
     default: 'true'
+  miniconda-version:
+    description: The version of miniconda to install
+    required: false
+    default: 'latest'
   python-version:
     description: The Python version to install
     required: true
@@ -72,7 +76,7 @@ runs:
         python-version: ${{ inputs.python-version }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        miniconda-version: "latest"
+        miniconda-version: ${{ inputs.miniconda-version }}
         auto-update-conda: ${{ inputs.conda-update }}
         # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest version
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -47,13 +47,6 @@ inputs:
     description: Whether to install playwright
     required: false
     default: 'false'
-  conda-mamba:
-    description: "DEPRECATED: Whether to use conda or mamba"
-    required: false
-    default: 'conda'
-    options:
-      - 'conda'
-      - 'mamba'
 outputs:
   cache-hit:
     description: Whether the cache was hit

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -96,10 +96,9 @@ runs:
       id: cache
     - if: inputs.conda-mamba == 'mamba' && steps.cache.outputs.cache-hit != 'true'
       run: |
-        echo "::group::Setup mamba"
+        echo "::group::Setup libmamba-solver"
         conda install -n base conda-libmamba-solver
         conda config --set solver libmamba
-        echo "alias mamba=conda" >> ~/.bashrc
         echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
@@ -126,7 +125,7 @@ runs:
         conda config --env --set channel_priority ${{ inputs.channel-priority }}
         conda config --show-sources
         conda info
-        ${{ inputs.conda-mamba }} install python=${{ inputs.python-version }} pyctdev nomkl
+        conda install python=${{ inputs.python-version }} pyctdev nomkl
         echo "::endgroup::"
       shell: bash -el {0}
     - if: inputs.cache == 'true' && steps.cache.outputs.cache-hit == 'true'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -98,7 +98,7 @@ runs:
       run: |
         echo "::group::Setup mamba"
         echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
-        conda install mamba -c conda-forge -n base
+        conda install mamba -c conda-forge -n base --solver classic
         conda run -n base mamba init --all
         echo "::endgroup::"
       shell: bash -el {0}


### PR DESCRIPTION
Mamba was working correctly on macOS and could not easily be fixed, so I have updated the action to _only_ use the conda+libmamba solver. 

Because `pyctdev` installs conda in its environment, we need to install `conda-libmamba-solver` in it.

I tried adding an `alias mamba=conda` into the `.bashrc` for backward compatibility with previous tasks, but I could not get it to work. So if we make a new release, it should not be a micro bump.

Check passes: https://github.com/holoviz/holoviews/pull/5804