### PR TITLE
Update install task and create pre-commit task

### DIFF
--- a/install/action.yaml
+++ b/install/action.yaml
@@ -82,10 +82,10 @@ runs:
       run: echo "ENVS_PATH=${{ format('{0}/{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
       shell: bash -el {0}
     - if: inputs.cache == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
         path: ${{ env.ENVS_PATH }}
-        key: ${{ inputs.name  }}-${{ runner.os }}-${{ inputs.conda-mamba }}-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
+        key: ${{ inputs.name  }}-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
       id: cache
     - run: |
         echo "::group::Setup conda-libmamba-solver"
@@ -180,3 +180,8 @@ runs:
         doit env_capture
         echo "::endgroup::"
       shell: bash -el {0}
+    - if: inputs.cache == 'true' && steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ env.ENVS_PATH }}
+        key: ${{ inputs.name  }}-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}


### PR DESCRIPTION
This PR will implement the following:
- [ ] Add restore and save cache also to cache failing environments.
- [ ] Save environments from runs
- [ ] Create a new pre-commit install task which outputs to the summary dashboard

This will be tested with https://github.com/holoviz/holoviews/pull/5905