### PR TITLE
Add payload to downstream tests

### DIFF
--- a/.github/workflows/run_downstream_tests.yaml
+++ b/.github/workflows/run_downstream_tests.yaml
@@ -15,6 +15,11 @@ on:
         description: 'A JSON string of downstream repos to test'
         required: true
         type: string
+      client_payload:
+        description: 'A JSON string of client payload to pass to downstream tests'
+        default: '{"cache": false}' # Should be something like this: '{"target": "downstream", "cache": false}'
+        required: false
+        type: string
     secrets:
       ACCESS_TOKEN:
         required: true
@@ -80,28 +85,13 @@ jobs:
     timeout-minutes: 240
     steps:
     - name: Trigger downstream test workflow and wait
-      if: matrix.downstream_repo != 'holoviews'
       uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
         owner: holoviz
         repo: ${{ matrix.downstream_repo }}
         github_token: ${{ secrets.ACCESS_TOKEN }}
         workflow_file_name: test.yaml
-        ref: main
-        wait_interval: 120
-        propagate_failure: true
-        trigger_workflow: true
-        wait_workflow: true
-    # Payload is only supported for now in HoloViews
-    - name: Trigger downstream test workflow and wait
-      if: matrix.downstream_repo == 'holoviews'
-      uses: convictional/trigger-workflow-and-wait@v1.6.5
-      with:
-        owner: holoviz
-        repo: ${{ matrix.downstream_repo }}
-        github_token: ${{ secrets.ACCESS_TOKEN }}
-        workflow_file_name: test.yaml
-        client_payload: '{"target": "downstream", "cache": false}'
+        client_payload: ${{ inputs.client_payload }}
         ref: main
         wait_interval: 120
         propagate_failure: true

--- a/.github/workflows/run_downstream_tests.yaml
+++ b/.github/workflows/run_downstream_tests.yaml
@@ -18,8 +18,8 @@ jobs:
     name: Check if new version of {{ env.UPSTREAM_REPO }} available on pyviz/label/dev
     runs-on: ubuntu-latest
     # Run only if the caller workflow has completed with success,
-    # or if it has a `manual` input set to true. 
-    if: ${{ (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success') || github.event.inputs.manual == 'true' }} 
+    # or if it has a `manual` input set to true.
+    if: ${{ (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success') || github.event.inputs.manual == 'true' }}
     timeout-minutes: 10
     steps:
     - name: Print event data
@@ -53,7 +53,7 @@ jobs:
         # it'll be set to the version found in the metadata, i.e. 1.12.1a1 (jq -r removes
         # the surrounding quotes).
         # Using only pyviz/label/dev for the search, since dev releases and releases can
-        # both be found in this channel. 
+        # both be found in this channel.
         echo "version=$(conda search --override-channels -c pyviz/label/dev '${{ env.UPSTREAM_REPO }}==${{ steps.from_git.outputs.version }}' --json | jq -r '.${{ env.UPSTREAM_REPO }}[0].version')"  >> $GITHUB_OUTPUT
     - name: Print tag and conda version found
       run: |
@@ -71,12 +71,28 @@ jobs:
     timeout-minutes: 240
     steps:
     - name: Trigger downstream test workflow and wait
+      if: matrix.downstream_repo != 'holoviews'
       uses: convictional/trigger-workflow-and-wait@v1.6.5
       with:
         owner: holoviz
         repo: ${{ matrix.downstream_repo }}
         github_token: ${{ secrets.ACCESS_TOKEN }}
         workflow_file_name: test.yaml
+        ref: main
+        wait_interval: 120
+        propagate_failure: true
+        trigger_workflow: true
+        wait_workflow: true
+    # Payload is only supported for now in HoloViews
+    - name: Trigger downstream test workflow and wait
+      if: matrix.downstream_repo == 'holoviews'
+      uses: convictional/trigger-workflow-and-wait@v1.6.5
+      with:
+        owner: holoviz
+        repo: ${{ matrix.downstream_repo }}
+        github_token: ${{ secrets.ACCESS_TOKEN }}
+        workflow_file_name: test.yaml
+        payload: '{"target": "downstream", "cache": false}'
         ref: main
         wait_interval: 120
         propagate_failure: true

--- a/.github/workflows/run_downstream_tests.yaml
+++ b/.github/workflows/run_downstream_tests.yaml
@@ -101,7 +101,7 @@ jobs:
         repo: ${{ matrix.downstream_repo }}
         github_token: ${{ secrets.ACCESS_TOKEN }}
         workflow_file_name: test.yaml
-        payload: '{"target": "downstream", "cache": false}'
+        client_payload: '{"target": "downstream", "cache": false}'
         ref: infrastructure2 # main
         wait_interval: 120
         propagate_failure: true

--- a/.github/workflows/run_downstream_tests.yaml
+++ b/.github/workflows/run_downstream_tests.yaml
@@ -102,7 +102,7 @@ jobs:
         github_token: ${{ secrets.ACCESS_TOKEN }}
         workflow_file_name: test.yaml
         payload: '{"target": "downstream", "cache": false}'
-        ref: main
+        ref: infrastructure2 # main
         wait_interval: 120
         propagate_failure: true
         trigger_workflow: true

--- a/.github/workflows/run_downstream_tests.yaml
+++ b/.github/workflows/run_downstream_tests.yaml
@@ -35,7 +35,7 @@ env:
 
 jobs:
   check_if_new_version_available:
-    name: Check if new version of {{ env.UPSTREAM_REPO }} available on pyviz/label/dev
+    name: Check if new version of ${{ env.UPSTREAM_REPO }} available on pyviz/label/dev
     runs-on: ubuntu-latest
     # Run only if the caller workflow has completed with success,
     # or if it has a `manual` input set to true.

--- a/.github/workflows/run_downstream_tests.yaml
+++ b/.github/workflows/run_downstream_tests.yaml
@@ -9,6 +9,15 @@ on:
     secrets:
       ACCESS_TOKEN:
         required: true
+  workflow_dispatch:
+    inputs:
+      downstream_repos_as_json:
+        description: 'A JSON string of downstream repos to test'
+        required: true
+        type: string
+    secrets:
+      ACCESS_TOKEN:
+        required: true
 
 env:
   UPSTREAM_REPO: ${{ github.event.repository.name }}

--- a/.github/workflows/run_downstream_tests.yaml
+++ b/.github/workflows/run_downstream_tests.yaml
@@ -48,7 +48,7 @@ jobs:
       run: echo "$EVENT"
     - name: Install jq
       run: sudo apt install -y jq
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout repo
       with:
         fetch-depth: "1"
@@ -58,7 +58,7 @@ jobs:
       id: from_git
       run: |
         echo "version=$(git tag -l --sort=-creatordate | head -n 1 | cut -c 2-)" >> $GITHUB_OUTPUT
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       name: Install conda with miniconda
       with:
         miniconda-version: "latest"

--- a/.github/workflows/run_downstream_tests.yaml
+++ b/.github/workflows/run_downstream_tests.yaml
@@ -4,7 +4,13 @@ on:
   workflow_call:
     inputs:
       downstream_repos_as_json:
+        description: 'A JSON string of downstream repos to test'
         required: true
+        type: string
+      client_payload:
+        description: 'A JSON string of client payload to pass to downstream tests'
+        default: '{"target": "downstream", "cache": false}'
+        required: false
         type: string
     secrets:
       ACCESS_TOKEN:
@@ -17,7 +23,7 @@ on:
         type: string
       client_payload:
         description: 'A JSON string of client payload to pass to downstream tests'
-        default: '{"cache": false}' # Should be something like this: '{"target": "downstream", "cache": false}'
+        default: '{"target": "downstream", "cache": false}'
         required: false
         type: string
     secrets:

--- a/.github/workflows/run_downstream_tests.yaml
+++ b/.github/workflows/run_downstream_tests.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     # Run only if the caller workflow has completed with success,
     # or if it has a `manual` input set to true.
-    if: ${{ (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success') || github.event.inputs.manual == 'true' }}
+    if: ${{ (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success') || github.event.inputs.manual == 'true' || github.event_name == 'workflow_dispatch' }}
     timeout-minutes: 10
     steps:
     - name: Print event data
@@ -69,7 +69,7 @@ jobs:
         echo "git tag: ${{ steps.from_git.outputs.version }}"
         echo "conda version: ${{ steps.from_conda.outputs.version }}"
     - name: Stop if git tag and conda version are different
-      if: ${{ steps.from_git.outputs.version != steps.from_conda.outputs.version }}
+      if: ${{ steps.from_git.outputs.version != steps.from_conda.outputs.version && github.event_name != 'workflow_dispatch' }}
       run: exit 1
   downstream_tests:
     needs: check_if_new_version_available

--- a/.github/workflows/run_downstream_tests.yaml
+++ b/.github/workflows/run_downstream_tests.yaml
@@ -102,7 +102,7 @@ jobs:
         github_token: ${{ secrets.ACCESS_TOKEN }}
         workflow_file_name: test.yaml
         client_payload: '{"target": "downstream", "cache": false}'
-        ref: infrastructure2 # main
+        ref: main
         wait_interval: 120
         propagate_failure: true
         trigger_workflow: true


### PR DESCRIPTION
This will, in combination with the changes in https://github.com/holoviz/holoviews/pull/6043, make it possible to send a payload to run only the downstream option matrix without cache.   

![image](https://github.com/holoviz-dev/holoviz_tasks/assets/19758978/710c6ded-5594-43b0-8082-9f04f85428ec)
