### PR TITLE
ci: Don't install for lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # holoviz_tasks
 
 Shared GHA workflows and tasks used to maintain the HoloViz repositories
+
+## Release
+
+To make an releasetag the commit with the version number and push it to the repo.
+
+```bash
+git tag -a v0.1.X -m "Version 0.1.X"
+git push --tags v0.1.X
+```
+
+Afterwards merge the commits up tag into `v0` branch. This is branch is used across
+projects to not manually update to the latests tag.
+
+``` bash
+git checkout v0
+git merge main
+git push origin v0
+```

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Shared GHA workflows and tasks used to maintain the HoloViz repositories
 
 ## Release
 
-To make an releasetag the commit with the version number and push it to the repo.
+To make a release tag the commit with the version number and push it to the repo.
 
 ```bash
 git tag -a v0.1.X -m "Version 0.1.X"
 git push --tags v0.1.X
 ```
 
-Afterwards merge the commits up tag into `v0` branch. This is branch is used across
+Afterwards merge the commits up tag into `v0` branch. This branch is used across
 projects to not manually update to the latests tag.
 
 ``` bash

--- a/pixi_lock/action.yaml
+++ b/pixi_lock/action.yaml
@@ -30,11 +30,16 @@ runs:
         key: pixi|${{ env.TODAY }}|${{ hashFiles('pixi.toml') }}
     - uses: prefix-dev/setup-pixi@v0.8.1
       if: steps.cache.outputs.cache-hit != 'true'
-      id: install
       with:
         pixi-version: ${{ inputs.pixi-version }}
         manifest-path: ${{ inputs.pixi-manifest-path }}
         run-install: false
+    - name: Run update  # So we don't need to download default
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        echo "::group::Update"
+        pixi update
+        echo "::endgroup::"
     - uses: actions/upload-artifact@v4
       with:
         name: pixi-lock

--- a/pixi_lock/action.yaml
+++ b/pixi_lock/action.yaml
@@ -34,7 +34,7 @@ runs:
         pixi-version: ${{ inputs.pixi-version }}
         manifest-path: ${{ inputs.pixi-manifest-path }}
         run-install: false
-    - name: Run update  # So we don't need to download default
+    - name: Run update  # Using `pixi update` so we don't need to create and download the default environment.
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash -e {0}
       run: |

--- a/pixi_lock/action.yaml
+++ b/pixi_lock/action.yaml
@@ -34,6 +34,7 @@ runs:
       with:
         pixi-version: ${{ inputs.pixi-version }}
         manifest-path: ${{ inputs.pixi-manifest-path }}
+        run-install: false
     - uses: actions/upload-artifact@v4
       with:
         name: pixi-lock

--- a/pixi_lock/action.yaml
+++ b/pixi_lock/action.yaml
@@ -36,6 +36,7 @@ runs:
         run-install: false
     - name: Run update  # So we don't need to download default
       if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash -e {0}
       run: |
         echo "::group::Update"
         pixi update


### PR DESCRIPTION
As it is used as an intermediate step. Related to changes made in https://github.com/holoviz/holoviews/pull/6456, where we want to make a bigger default env for improved developer experience.  