### PR TITLE
chore: Update headless display version

### DIFF
--- a/pixi_install/action.yaml
+++ b/pixi_install/action.yaml
@@ -62,7 +62,7 @@ runs:
         echo "PYDEVD_DISABLE_FILE_VALIDATION=1" >> $GITHUB_ENV
     - name: OpenGL
       if: inputs.opengl == 'true'
-      uses: pyvista/setup-headless-display-action@v2
+      uses: pyvista/setup-headless-display-action@v3
       with:
         pyvista: false
     - uses: actions/download-artifact@v4


### PR DESCRIPTION
Ubuntu 24.04 fails:

![image](https://github.com/user-attachments/assets/8d9a213a-3374-4ac4-88ba-45f2c7e73536)
