### PR TITLE
docs_publish: remove the v prefix

### DIFF
--- a/docs-publish/action.yaml
+++ b/docs-publish/action.yaml
@@ -124,7 +124,8 @@ runs:
         if [ "$GH_EVENT_NAME" = "workflow_dispatch" ]; then
           VERSION="$INPUT_VERSION"
         else
-          VERSION="$TAG_VERSION"
+          # Remove the "v" prefix
+          VERSION="${TAG_VERSION:1}"
         fi
         # Remove s3://
         BUCKET_NAME="${S3_URL:5}"


### PR DESCRIPTION
In hvPlot the switcher references the `x.x.x` docs build, but when we make a final release we upload it at `vx.x.x` (note the `v`). Let's not include the `v` prefix.