### PR TITLE
Fix validate-pr-title

### DIFF
--- a/validate-pr-title/validate.sh
+++ b/validate-pr-title/validate.sh
@@ -16,7 +16,7 @@ to_list() {
 
 types_pattern="$(to_pattern "$TYPES")"
 scopes_pattern="$(to_pattern "$SCOPES")"
-pattern="^(${types_pattern})(\\((${scopes_pattern})\\))?(!)?: [a-zA-Z].+"
+pattern="^(${types_pattern})(\\((${scopes_pattern})\\))?(!)?: [^ ].+"
 
 if ! printf '%s\n' "$TITLE" | grep -Eq "$pattern"; then
     cat <<EOF


### PR DESCRIPTION
Saw that <code>fix: `NdMapping` explicit tuple set slicing with dimension values</code> failed because it started with a <code>`</code>. This now only check that the first item after the space is not another space. 